### PR TITLE
Improve toggle's accessibility

### DIFF
--- a/src/save.js
+++ b/src/save.js
@@ -41,12 +41,14 @@ export default function Save( { attributes } ) {
 			>
 				<input
 					type="checkbox"
+					role="switch"
 					className="wp-block-tabor-dark-mode-toggle__input"
 					id="theme-toggle"
 					aria-label={ __(
 						'Toggle dark mode',
 						'dark-mode-toggle-block'
 					) }
+					aria-live="polite"
 				/>
 				<span
 					className={ classnames(

--- a/src/style.scss
+++ b/src/style.scss
@@ -24,6 +24,10 @@
 	position: absolute;
 	white-space: nowrap;
 	width: 1px;
+
+	&:focus-visible + .wp-block-tabor-appearance-toggle__track
+		outline: auto;
+	}
 }
 
 .wp-block-tabor-dark-mode-toggle__track {


### PR DESCRIPTION
This PR improves the toggle's accessibility in two ways:

- For screen readers: adding the `role="switch"` and `aria-live="polite"` attributes to ensure clarity of actions.
- For keyboard navigation: highlighting the toggle when focus is visible on the input.