### PR TITLE
Fixes width and font size across different themes

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -1,5 +1,7 @@
 .wp-block-tabor-dark-mode-toggle {
+	width: fit-content;
 	--icon-size: 16px;
+	font-size: var(--icon-size);
 
 	&.is-medium {
 		--icon-size: 18px;


### PR DESCRIPTION
This pull request makes a minor style adjustment to the `wp-block-tabor-dark-mode-toggle` component to improve its layout.

- Style Improvement:
  * Added `width: fit-content;` and set `font-size` to `var(--icon-size)` in `src/style.scss` to ensure the toggle's width fits its content and its font size matches the icon size.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts `wp-block-tabor-dark-mode-toggle` to use `width: fit-content` and `font-size: var(--icon-size)` for consistent sizing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4caaed3b55bc2bee51bceb42c0346649c1e03bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->